### PR TITLE
Fixed configuration order

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,24 +1,20 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+
+Vagrant.configure(2) do |config|
+  # any configuration that needs to be done before the reddit setup happens
+  config.vm.define "default" do |redditlocal|
+    redditlocal.vm.provider "virtualbox" do |v|
+      v.cpus = 2
+    end
+    # pre-setup
+    redditlocal.vm.provision "file", source: "r2/development.update", destination: "~/src/reddit/r2/development.update"
+  end
+
+end
+
 # we take advantage of the fact that the reddit Vagrantfile mounts the parent directory
 # and ends up using the relative path "../reddit/" for the source to run the virtualized application on
 # under normal circumstances this path ends up being the same as "."
 load "../reddit/Vagrantfile"
-
-Vagrant.configure(2) do |config|
-  # any configuration that needs to be done after the reddit setup happens
-  config.vm.define "default" do |redditlocal|
-    # post-setup
-    redditlocal.vm.provision "file", source: "r2/development.update", destination: "~/src/reddit/r2/development.mito.update"
-
-    redditlocal.vm.provision "shell", inline: <<-SCRIPT
-      cd src/reddit/r2
-      sudo -u vagrant ./updateini.py development.ini development.mito.update > development.mito.ini
-      ln -sf development.mito.ini run.ini
-      reddit-stop
-      reddit-start
-    SCRIPT
-  end
-
-end

--- a/r2/development.update
+++ b/r2/development.update
@@ -1,3 +1,29 @@
+# after editing this file, run "make ini" to
+# generate a new development.ini
+
+[DEFAULT]
+# global debug flag -- displays pylons stacktrace rather than 500 page on error when true
+# WARNING: a pylons stacktrace allows remote code execution. Make sure this is false
+# if your server is publicly accessible.
+debug = true
+
+disable_ads = true
+disable_captcha = true
+disable_ratelimit = true
+disable_require_admin_otp = true
+
+domain = ""
+oauth_domain = ""
+
+plugins = ""
+
+media_provider = filesystem
+media_fs_root = /srv/www/media
+media_fs_base_url_http = http://%(domain)s/media/
+
+[server:main]
+port = 8001
+
 db_table_link = thing, !typeid=3
 db_table_account = thing, !typeid=2
 db_table_message = thing, !typeid=4


### PR DESCRIPTION
Fixes a bug with previous setup where configuration being retroactively applied caused a 503 error.

To test:
`vagrant up` and verify you can hit the local instance without a 503.