### PR TITLE
Add setup and configuration for reddit image resizer patch and refresh_token

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,6 +1,8 @@
 Notes
 ---
 
+This doc is mostly notes for Ops
+
 - Reddit app will run if a plugin is missing
 - Reddit app will **not** run if a provider is missing
 - Reddit/Pylons uses `pkg_resources.WorkingSet` to load plugins/provider (see next note).

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,12 @@
+Notes
+---
+
+- Reddit app will run if a plugin is missing
+- Reddit app will **not** run if a provider is missing
+- Reddit/Pylons uses `pkg_resources.WorkingSet` to load plugins/provider (see next note).
+- Plugins/providers need to be installed at the global level by invoking this:
+    ```
+    python setup.py build
+    sudo python setup.py develop --no-deps
+    ```
+- `db_table_*` needs to be configured **before** the Reddit application is started the first time or runtime errors will occur

--- a/README.md
+++ b/README.md
@@ -3,7 +3,15 @@
 Custom extension of reddit Vagrant setup to allow custom configuration
 
 
-### Usage
-
-    # setup and provision
-    vagrant up
+### Setup
+```bash
+cd ..
+git clone git@github.com:reddit/reddit.git
+git clone git@github.com:mitodl/reddit-config.git
+git clone git@github.com:mitodl/refresh_token.git
+git clone git@github.com:mitodl/no_op2_resizer.git
+cd reddit
+git apply ../reddit-config/patches/configure_tracing.patch
+cd ../reddit-config
+vagrant up
+```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,7 +37,7 @@ Vagrant.configure(2) do |config|
         popd
       }
 
-      setup_reddit_ext src/reddit_no_op2_resizer
+      setup_reddit_ext src/no_op2_resizer
       setup_reddit_ext src/refresh_token
     SCRIPT
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,24 +1,20 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+
+Vagrant.configure(2) do |config|
+  # any configuration that needs to be done before the reddit setup happens
+  config.vm.define "default" do |redditlocal|
+    redditlocal.vm.provider "virtualbox" do |v|
+      v.cpus = 2
+    end
+    # pre-setup
+    redditlocal.vm.provision "file", source: "r2/development.update", destination: "~/src/reddit/r2/development.update"
+  end
+
+end
+
 # we take advantage of the fact that the reddit Vagrantfile mounts the parent directory
 # and ends up using the relative path "../reddit/" for the source to run the virtualized application on
 # under normal circumstances this path ends up being the same as "."
 load "../reddit/Vagrantfile"
-
-Vagrant.configure(2) do |config|
-  # any configuration that needs to be done after the reddit setup happens
-  config.vm.define "default" do |redditlocal|
-    # post-setup
-    redditlocal.vm.provision "file", source: "r2/development.update", destination: "~/src/reddit/r2/development.mito.update"
-
-    redditlocal.vm.provision "shell", inline: <<-SCRIPT
-      cd src/reddit/r2
-      sudo -u vagrant ./updateini.py development.ini development.mito.update > development.mito.ini
-      ln -sf development.mito.ini run.ini
-      reddit-stop
-      reddit-start
-    SCRIPT
-  end
-
-end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,10 +11,43 @@ Vagrant.configure(2) do |config|
     # pre-setup
     redditlocal.vm.provision "file", source: "r2/development.update", destination: "~/src/reddit/r2/development.update"
   end
-
 end
 
 # we take advantage of the fact that the reddit Vagrantfile mounts the parent directory
 # and ends up using the relative path "../reddit/" for the source to run the virtualized application on
 # under normal circumstances this path ends up being the same as "."
 load "../reddit/Vagrantfile"
+
+Vagrant.configure(2) do |config|
+  # any configuration that needs to be done after the reddit setup happens
+  config.vm.define "default" do |redditlocal|
+    # post-setup
+    redditlocal.vm.provision "shell", inline: <<-SCRIPT
+      function setup_reddit_ext() {
+        pushd .
+        DIR=$1
+        if [[ -d $DIR ]] ;
+        then
+          cd $DIR
+          python setup.py build
+          sudo python setup.py develop --no-deps
+        else
+          echo "$DIR doesn't exist"
+        fi
+        popd
+      }
+
+      setup_reddit_ext src/reddit_no_op2_resizer
+      setup_reddit_ext src/refresh_token
+    SCRIPT
+
+    redditlocal.vm.provision "file", source: "r2/plugins.update", destination: "~/src/reddit/r2/plugins.update"
+
+    redditlocal.vm.provision "shell", inline: <<-SCRIPT
+      cd src/reddit/r2
+      mv development.ini development.old.ini
+      python updateini.py development.old.ini plugins.update > development.ini
+      sudo reddit-restart
+    SCRIPT
+  end
+end

--- a/patches/configure_tracing.patch
+++ b/patches/configure_tracing.patch
@@ -1,0 +1,13 @@
+diff --git a/r2/r2/lib/app_globals.py b/r2/r2/lib/app_globals.py
+index 6e58480..b66f4c2 100644
+--- a/r2/r2/lib/app_globals.py
++++ b/r2/r2/lib/app_globals.py
+@@ -479,7 +479,7 @@ class Globals(object):
+         self.baseplate.configure_logging()
+         self.baseplate.register(R2BaseplateObserver())
+         self.baseplate.configure_tracing(
+-            service_name="r2",
++            tracing_client="r2",
+             tracing_endpoint=self.config.get("tracing_endpoint"),
+             sample_rate=self.config.get("tracing_sample_rate"),
+         )

--- a/r2/development.update
+++ b/r2/development.update
@@ -15,14 +15,9 @@ disable_require_admin_otp = true
 domain = ""
 oauth_domain = ""
 
-plugins = ""
-
 media_provider = filesystem
 media_fs_root = /srv/www/media
 media_fs_base_url_http = http://%(domain)s/media/
-
-[server:main]
-port = 8001
 
 db_table_link = thing, !typeid=3
 db_table_account = thing, !typeid=2
@@ -42,3 +37,7 @@ db_table_award = thing, !typeid=6
 db_table_trophy = relation, account, award, !typeid=18
 db_table_flair = relation, subreddit, account, !typeid=19
 db_table_promocampaign = thing, !typeid=8
+
+
+[server:main]
+port = 8001

--- a/r2/development.update
+++ b/r2/development.update
@@ -1,3 +1,29 @@
+# after editing this file, run "make ini" to
+# generate a new development.ini
+
+[DEFAULT]
+# global debug flag -- displays pylons stacktrace rather than 500 page on error when true
+# WARNING: a pylons stacktrace allows remote code execution. Make sure this is false
+# if your server is publicly accessible.
+debug = true
+
+disable_ads = true
+disable_captcha = true
+disable_ratelimit = true
+disable_require_admin_otp = true
+
+domain = ""
+oauth_domain = ""
+
+plugins = ""
+
+media_provider = filesystem
+media_fs_root = /srv/www/media
+media_fs_base_url_http = http://%(domain)s/media/
+
+[server:main]
+port = 8001
+
 db_table_link = thing, !typeid=3
 db_table_account = thing, !typeid=2
 db_table_message = thing, !typeid=4

--- a/r2/plugins.update
+++ b/r2/plugins.update
@@ -1,0 +1,7 @@
+[DEFAULT]
+
+# patch the image resizer setting
+image_resizing_provider = no_op2
+
+plugins = refresh_token
+#plugins = refresh_token,no_op2_resizer


### PR DESCRIPTION
This patches reddit with a custom resizer that doesn't error on the callsite. It also adds our refresh_token plugin as well.

To test:

- `git clone` this repo, mitodl/refresh_token, and mitodl/no_op2_resizer alongside your reddit/reddit checkout.
- Rebuild your vagrant: `vagrant destroy -f && vagrant up`
- Verify you can hit the reddit.local site and see no errors in `/var/log/upstart/reddit-pastor.log`